### PR TITLE
adds reverse dns support

### DIFF
--- a/lib/landrush/action/setup.rb
+++ b/lib/landrush/action/setup.rb
@@ -43,6 +43,7 @@ module Landrush
         global_config.landrush.hosts.each do |hostname, dns_value|
           info "adding static entry: #{hostname} => #{dns_value}"
           Store.hosts.set hostname, dns_value
+	  Store.hosts.set("#{dns_value.split('.').reverse.join('.')}.in-addr.arpa.", hostname)
         end
       end
 
@@ -52,6 +53,7 @@ module Landrush
         info "adding machine entry: #{machine_hostname} => #{ip_address}"
 
         Store.hosts.set(machine_hostname, ip_address)
+	Store.hosts.set("#{ip_address.split('.').reverse.join('.')}.in-addr.arpa.", machine_hostname)
       end
 
       def private_network_exists?

--- a/lib/landrush/action/teardown.rb
+++ b/lib/landrush/action/teardown.rb
@@ -23,14 +23,17 @@ module Landrush
       end
 
       def teardown_machine_dns
+        ip_address = machine.guest.capability(:read_host_visible_ip_address)
         info "removing machine entry: #{machine_hostname}"
         Store.hosts.delete(machine_hostname)
+	Store.hosts.delete("#{ip_address.split('.').reverse.join('.')}.in-addr.arpa.")
       end
 
       def teardown_static_dns
-        global_config.landrush.hosts.each do |static_hostname, _|
+        global_config.landrush.hosts.each do |static_hostname, dns_value|
           info "removing static entry: #{static_hostname}"
           Store.hosts.delete static_hostname
+	  Store.hosts.delete("#{dns_value.split('.').reverse.join('.')}.in-addr.arpa.")
         end
       end
 

--- a/lib/landrush/server.rb
+++ b/lib/landrush/server.rb
@@ -59,6 +59,16 @@ module Landrush
           end
         end
 
+        match(/.*/, IN::PTR) do |transaction|
+           host = Store.hosts.find(transaction.name)
+           if host
+             transaction.respond!(Name.create(Store.hosts.get(host)))
+           else
+             transaction.passthrough!(server.upstream)
+           end
+        end
+
+
         # Default DNS handler
         otherwise do |transaction|
           transaction.passthrough!(server.upstream)

--- a/lib/landrush/store.rb
+++ b/lib/landrush/store.rb
@@ -28,14 +28,6 @@ module Landrush
 
     def get(key)
       value = current_config[key]
-      redirect = find(value)
-      if value
-        if redirect
-          get(redirect)
-        else
-          value
-        end
-      end
     end
 
     def clear!


### PR DESCRIPTION
This patch adds support for reverse dns queries (e.g. `host 10.250.0.11`)

This works for me, but I'm a novice ruby coder and may be overlooking something.  In particular, I had to remove the "redirect" in `Store.hosts.get()` for my implementation to work.