### PR TITLE
update vagrant version to 1.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 group :development do
   gem 'vagrant',
     :git => 'git://github.com/mitchellh/vagrant.git',
-    :ref => 'v1.6.1'
+    :ref => 'v1.7.1'
 
   gem 'byebug'
   gem 'mocha'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,6 +59,10 @@ class Landrush::FakeProvider
 
   def ssh_info
   end
+
+  def state
+    @state ||= Vagrant::MachineState.new('fake-state', 'fake-state','fake-state')
+  end
 end
 
 class Landrush::FakeConfig


### PR DESCRIPTION
Hi, I couldn't get it to bundle because the vagrant you locked on had some kind of incompatibility with my bundler version, so I updated the vagrant version, was a small fix getting the specs to pass.