### PR TITLE
Rubydns 0 9 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,16 @@ source 'https://rubygems.org'
 # Can't use `gemspec` to pull in dependencies, because the landrush gem needs
 # to be in the :plugins group for Vagrant to detect and load it in development
 
-gem 'rubydns', '0.7.3'
+gem 'rubydns', '0.9.4'
 gem 'rake'
 
 # Vagrant's special group
 group :plugins do
   gem 'landrush', path: '.'
+end
+
+group :test do
+  gem 'rexec'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 group :development do
   gem 'vagrant',
     :git => 'git://github.com/mitchellh/vagrant.git',
-    :ref => 'v1.6.1'
+    :ref => 'v1.7.1'
 
   gem 'byebug'
   gem 'mocha'

--- a/landrush.gemspec
+++ b/landrush.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubydns', '0.7.3'
+  spec.add_dependency 'rubydns', '0.9.4'
 end

--- a/lib/landrush/server.rb
+++ b/lib/landrush/server.rb
@@ -1,4 +1,5 @@
 require 'rubydns'
+require 'rexec/daemon'
 
 module Landrush
   class Server < RExec::Daemon::Base

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,6 +59,10 @@ class Landrush::FakeProvider
 
   def ssh_info
   end
+
+  def state
+    @state ||= Vagrant::MachineState.new('fake-state', 'fake-state','fake-state')
+  end
 end
 
 class Landrush::FakeConfig


### PR DESCRIPTION
This pull request upgrades to the latest version of rubydns, no idea if it's necessary, but it seems 0.7.3 is a bit buggy. All specs pass, I'm not sure if they cover enough for you to be sure this upgrade is good. I haven't run it in production yet.

The specs did become very chatty, RubyDNS is logging all kinds of information.