### PR TITLE
include rexec in gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 # to be in the :plugins group for Vagrant to detect and load it in development
 
 gem 'rubydns', '0.9.4'
+gem 'rexec'
 gem 'rake'
 
 # Vagrant's special group
@@ -12,7 +13,6 @@ group :plugins do
 end
 
 group :test do
-  gem 'rexec'
 end
 
 group :development do

--- a/landrush.gemspec
+++ b/landrush.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubydns', '0.9.4'
+  spec.add_dependency 'rexec'
 end


### PR DESCRIPTION
I didn't know that you use rexec in the gem itself as well, not just the tests. This adds the dependency. I've tested it and with this fix the gem seems to work when installed as a vagrant plugin.