### PR TITLE
Add support for IN::PTR records.

### DIFF
--- a/lib/landrush/action/setup.rb
+++ b/lib/landrush/action/setup.rb
@@ -55,6 +55,7 @@ module Landrush
           if !Store.hosts.has?(hostname, dns_value)
             info "adding static entry: #{hostname} => #{dns_value}"
             Store.hosts.set hostname, dns_value
+            Store.hosts.set(IPAddr.new(dns_value).reverse, hostname)
           end
         end
       end
@@ -71,6 +72,7 @@ module Landrush
         if !Store.hosts.has?(machine_hostname, ip_address)
           info "adding machine entry: #{machine_hostname} => #{ip_address}"
           Store.hosts.set(machine_hostname, ip_address)
+          Store.hosts.set(IPAddr.new(ip_address).reverse, machine_hostname)
         end
       end
 

--- a/lib/landrush/action/teardown.rb
+++ b/lib/landrush/action/teardown.rb
@@ -27,7 +27,7 @@ module Landrush
       end
 
       def teardown_static_dns
-        config.hosts.each do |static_hostname, _|
+        config.hosts.each do |static_hostname, dns_value|
           if Store.hosts.has? static_hostname
             info "removing static entry: #{static_hostname}"
             Store.hosts.delete static_hostname

--- a/lib/landrush/server.rb
+++ b/lib/landrush/server.rb
@@ -61,6 +61,15 @@ module Landrush
           end
         end
 
+        match(/.*/, IN::PTR) do |transaction|
+          host = Store.hosts.find(transaction.name)
+          if host
+            transaction.respond!(Name.create(Store.hosts.get(host)))
+          else
+            transaction.passthrough!(server.upstream)
+          end
+        end
+
         # Default DNS handler
         otherwise do |transaction|
           transaction.passthrough!(server.upstream)

--- a/lib/landrush/store.rb
+++ b/lib/landrush/store.rb
@@ -23,7 +23,7 @@ module Landrush
     end
 
     def delete(key)
-      write(current_config.reject { |k, _| k == key })
+      write(current_config.reject { |k, v| k == key || v == key })
     end
 
     def has?(key, value = nil)
@@ -35,6 +35,7 @@ module Landrush
     end
 
     def find(search)
+      search = (IPAddr.new(search).reverse) if (IPAddr.new(search) rescue nil)
       current_config.keys.detect do |key|
         key.casecmp(search) == 0   ||
           search =~ /#{key}$/i     ||
@@ -45,8 +46,8 @@ module Landrush
     def get(key)
       value = current_config[key]
       redirect = nil
-      if value.is_a? String
-        redirect = find(value)
+      if value.is_a? String and ! (IPAddr.new(value) rescue nil)
+        redirect = find(value) if not current_config[value]
       end
       if value
         if redirect

--- a/test/landrush/server_test.rb
+++ b/test/landrush/server_test.rb
@@ -8,6 +8,12 @@ module Landrush
       answer_line.split.last
     end
 
+    def query_ptr(host)
+      output = `dig ptr -p #{Server.port} @127.0.0.1 #{host}`
+      answer_line = output.split("\n").grep(/^#{Regexp.escape(host)}/).first
+      answer_line.split.last
+    end
+
     describe 'start/stop' do
       it 'starts and stops a daemon' do
         Server.start
@@ -35,6 +41,8 @@ module Landrush
         Store.hosts.set(fake_host, fake_ip)
 
         query(fake_host).must_equal fake_ip
+        query_ptr(fake_host).must_equal fake_ip+'.'
+
       end
 
       it 'also resolves wildcard subdomains to a given machine' do


### PR DESCRIPTION
Building on the work done by @chadh in #21 I believe this should cover this feature. I also tried to clean it up a bit. So as to not add another gem dependency I used `ipaddr`. Its not as pretty but it gets the job done. I added two conditions to the redirect logic which seems to work. I added a test for the ptr record. Test pass.  