### PR TITLE
Add support for CNAME records.

### DIFF
--- a/lib/landrush/store.rb
+++ b/lib/landrush/store.rb
@@ -44,18 +44,7 @@ module Landrush
     end
 
     def get(key)
-      value = current_config[key]
-      redirect = nil
-      if value.is_a? String and ! (IPAddr.new(value) rescue nil)
-        redirect = find(value) if not current_config[value]
-      end
-      if value
-        if redirect
-          get(redirect)
-        else
-          value
-        end
-      end
+      current_config[key]
     end
 
     def clear!

--- a/test/landrush/server_test.rb
+++ b/test/landrush/server_test.rb
@@ -45,6 +45,20 @@ module Landrush
 
       end
 
+      it 'responds properly to configured cname entries' do
+        Server.start
+
+        fake_host = 'boogers.vagrant.dev'
+        fake_cname = 'snot.vagrant.dev'
+        fake_ip = '99.98.97.96'
+
+        Store.hosts.set(fake_host, fake_ip)
+        Store.hosts.set(fake_cname, fake_host)
+
+        query(fake_cname).must_equal fake_host+'.'
+
+      end
+
       it 'also resolves wildcard subdomains to a given machine' do
         Server.start
 


### PR DESCRIPTION
#96 added set and got me thinking about what I'd use that for. It quickly lead to CNAME and here's the patch that implements a simple CNAME lookup. Basically if a hostname exists as a value and a key this should work. You'll get a CNAME and the resulting A record for the corresponding entry.

Tests pass. No additional tests added per #96 it wasn't clear how to best add them. Happy to if there are suggestions.

-----

With support for set on the command line its trival for a user to:

  vagrant landrush set some.host.com some.other.com

Seems like we should check for possible CNAMEs in the current config.