### PR TITLE
Update to RubyDNS 1.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Can't use `gemspec` to pull in dependencies, because the landrush gem needs
 # to be in the :plugins group for Vagrant to detect and load it in development
 
-gem 'rubydns', '0.9.4'
+gem 'rubydns', '1.0.2'
 gem 'rexec'
 gem 'rake'
 

--- a/landrush.gemspec
+++ b/landrush.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubydns', '0.9.4'
+  spec.add_dependency 'rubydns', '1.0.2'
   spec.add_dependency 'rexec'
 end


### PR DESCRIPTION
Fixes #120. 

    Update to RubyDNS 1.0.2.

    Fixes #120. Celluloid 0.16.1 was released on Aug 8 which breaks RubyDNS.
    RubyDNS 1.0.2 pinned to Celluloid 0.16.0. This will be fixed further in
    a subsequent RubyDNS release.