### PR TITLE
Run redirect_dns after network interfaces are configured

### DIFF
--- a/lib/landrush/action/redirect_dns.rb
+++ b/lib/landrush/action/redirect_dns.rb
@@ -4,9 +4,12 @@ module Landrush
       include Common
 
       def call(env)
-        handle_action_stack(env) do
-          redirect_dns if enabled? and guest_redirect_dns?
-        end
+        handle_action_stack(env) {}
+
+        # This is after the middleware stack returns, which, since we're right
+        # before the Network action, should mean that all interfaces are good
+        # to go.
+        redirect_dns if enabled? and guest_redirect_dns?
       end
 
       def redirect_dns

--- a/lib/landrush/plugin.rb
+++ b/lib/landrush/plugin.rb
@@ -37,13 +37,13 @@ module Landrush
     def self.pre_boot_actions
       Vagrant::Action::Builder.new.tap do |b|
         b.use Action::Setup
+        b.use Action::RedirectDns
       end
     end
 
     def self.post_boot_actions
       Vagrant::Action::Builder.new.tap do |b|
         b.use Action::InstallPrerequisites
-        b.use Action::RedirectDns
       end
     end
 


### PR DESCRIPTION
I experienced that resolution on the guest would not work with Virtualbox.
The problem is that `ConfiguredDnsServers` reads `/etc/resolv.conf` *before* the interfaces are configured. And when Virtualbox configures the interfaces that file is changed again. So`Action::RedirectDns` creates iptables entries for an IP that's not the nameserver anymore.

Now I've copied a *hack* from `Action::Setup` to run the DNS redirection *after* the interfaces are set up.
The semantics in `Plugin` are a bit strange now - we register the action for `pre_boot_actions`, but the main work runs much later.

This works for Virtualbox, I don't have other platforms. But I think it should work too, as it's also used in `Action::Setup`.

@phinze wdyt?