### PR TITLE
Support libvirt provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased][unreleased]
 
+### Added
+ - vagrant: support for libvirt provider (#138)
+
 ## [0.18.0] - 2015-01-24
 
 ### Added

--- a/lib/landrush/action/common.rb
+++ b/lib/landrush/action/common.rb
@@ -3,6 +3,7 @@ module Landrush
     module Common
       SUPPORTED_PROVIDERS = {
         'VagrantPlugins::ProviderVirtualBox::Provider' => :virtualbox,
+        'VagrantPlugins::ProviderLibvirt::Provider'    => :libvirt,
         'HashiCorp::VagrantVMwarefusion::Provider'     => :vmware_fusion,
         'VagrantPlugins::Parallels::Provider'          => :parallels,
         'Landrush::FakeProvider'                       => :fake_provider,
@@ -26,6 +27,10 @@ module Landrush
 
       def virtualbox?
         provider == :virtualbox
+      end
+
+      def libvirt?
+        provider == :libvirt
       end
 
       def vmware?

--- a/lib/landrush/action/redirect_dns.rb
+++ b/lib/landrush/action/redirect_dns.rb
@@ -22,7 +22,7 @@ module Landrush
         case provider
         when :virtualbox then
           '10.0.2.2'
-        when :vmware_fusion then
+        when :vmware_fusion, :libvirt then
           _gateway_for_ip(machine.guest.capability(:configured_dns_servers).first)
         when :parallels then
           machine.provider.capability(:host_address)

--- a/lib/landrush/action/setup.rb
+++ b/lib/landrush/action/setup.rb
@@ -44,9 +44,17 @@ module Landrush
 
       def start_server
         return if Server.running?
-
-        info 'starting dns server'
-        Server.start
+        # We need to avoid forking with libvirt provider since the forked process
+        # would try to reuse the libvirt connection and fail.
+        if libvirt?
+          require 'open3'
+          Kernel.puts '[landrush] Starting landrush in background...'
+          _stdout, stderr, status = Open3.capture3('vagrant landrush start')
+          Kernel.puts stderr unless status
+        else
+          info 'starting dns server'
+          Server.start
+        end
       end
 
       def setup_static_dns

--- a/lib/landrush/plugin.rb
+++ b/lib/landrush/plugin.rb
@@ -21,6 +21,11 @@ module Landrush
       hook.before(VagrantPlugins::ProviderVirtualBox::Action::Network, pre_boot_actions)
       hook.after(Vagrant::Action::Builtin::WaitForCommunicator, post_boot_actions)
 
+      if defined?(VagrantPlugins::ProviderLibvirt)
+        hook.after(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks, pre_boot_actions)
+        hook.after(VagrantPlugins::ProviderLibvirt::Action::WaitTillUp, post_boot_actions)
+      end
+
       if defined?(HashiCorp::VagrantVMwarefusion)
         hook.before(HashiCorp::VagrantVMwarefusion::Action::Network, pre_boot_actions)
         hook.after(HashiCorp::VagrantVMwarefusion::Action::WaitForCommunicator, post_boot_actions)


### PR DESCRIPTION
Second attempt at libvirt support (issue #20).

We can't fork from Vagrant process when using libvirt provider, so we shell out using Open3. It's not the most elegant perhaps, but seems to do the work....