### PR TITLE
Changing default TLD from vagrant.dev to vagrant.test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,16 @@
 ## [Unreleased][unreleased]
-
-### Added
- - vagrant: support for libvirt provider (#138)
- - Add support for CNAME records (#99)
+- Added: Support for libvirt provider (#138)
+- Added: support for CNAME records (#99)
 
 ## [0.18.0] - 2015-01-24
-
-### Added
- - vagrant: support for `vagrant reload` (#101)
+- Added: support for `vagrant reload` (#101)
 
 ## [0.17.0] - 2015-01-18
-
-### Added
- - cli: `add` / `rm|del` subcommands (#96)
-
-### Fixed
- - cli: default to showing help when no command is specified
+- Added: cli `add` / `rm|del` subcommands (#96)
+- Fixed: cli: default to showing help when no command is specified
 
 ## [0.16.0] - 2015-01-18
-
-### Added
- - dns: support for IN::PTR records (#98)
+- Added: Support for IN::PTR records (#98)
 
 [unreleased]: https://github.com/phinze/landrush/compare/v0.18.0...HEAD
 [0.18.0]: https://github.com/phinze/landrush/compare/v0.17.0...v0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
  - vagrant: support for libvirt provider (#138)
+ - Add support for CNAME records (#99)
 
 ## [0.18.0] - 2015-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased][unreleased]
 - Added: Support for libvirt provider (#138)
 - Added: support for CNAME records (#99)
+- Breaking: Changing default TLD from `vagrant.dev` to `vagrant.test` (#118)
 
 ## [0.18.0] - 2015-01-24
 - Added: support for `vagrant reload` (#101)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Bring up a machine.
 
 And you should be able to get your hostname from your host:
 
-    $ dig -p 10053 @localhost myhost.vagrant.dev
+    $ dig -p 10053 @localhost myhost.vagrant.test
 
 If you shut down your guest, the entries associated with it will be removed.
 
@@ -55,9 +55,9 @@ This is great for overriding production services for nodes you might be testing 
 
 ### Wildcard Subdomains
 
-For your convenience, any subdomain of a DNS entry known to landrush will resolve to the same IP address as the entry. For example: given `myhost.vagrant.dev -> 1.2.3.4`, both `foo.myhost.vagrant.dev` and `bar.myhost.vagrant.dev` will also resolve to `1.2.3.4`.
+For your convenience, any subdomain of a DNS entry known to landrush will resolve to the same IP address as the entry. For example: given `myhost.vagrant.test -> 1.2.3.4`, both `foo.myhost.vagrant.test` and `bar.myhost.vagrant.test` will also resolve to `1.2.3.4`.
 
-If you would like to configure your guests to be accessible from the host as subdomains of something other than the default `vagrant.dev`, you can use the `config.landrush.tld` option in your Vagrantfile like so:
+If you would like to configure your guests to be accessible from the host as subdomains of something other than the default `vagrant.test`, you can use the `config.landrush.tld` option in your Vagrantfile like so:
 
     config.landrush.tld = 'vm'
 
@@ -96,10 +96,10 @@ Though it's not automatically set up by landrush, similar behavior can be achiev
 can integrate Landrush with dnsmasq on Ubuntu like so (tested on Ubuntu 13.10):
 
     sudo apt-get install -y resolvconf dnsmasq
-    sudo sh -c 'echo "server=/vagrant.dev/127.0.0.1#10053" > /etc/dnsmasq.d/vagrant-landrush'
+    sudo sh -c 'echo "server=/vagrant.test/127.0.0.1#10053" > /etc/dnsmasq.d/vagrant-landrush'
     sudo service dnsmasq restart
 
-If you use a TLD other than the default `vagrant.dev`, replace the TLD in the above instructions accordingly. Please be aware that anything ending in '.local' as TLD will not work because the `avahi` daemon reserves this TLD for its own uses.
+If you use a TLD other than the default `vagrant.test`, replace the TLD in the above instructions accordingly. Please be aware that anything ending in '.local' as TLD will not work because the `avahi` daemon reserves this TLD for its own uses.
 
 ### Visibility on other Devices (phone)
 

--- a/doc/proxy-mobile/README.md
+++ b/doc/proxy-mobile/README.md
@@ -28,7 +28,7 @@ In its configuration file forward all queries to your local Landrush and disable
 
 After restarting bind you should be able to resolve your VM's entries on your local default DNS server (port 53):
 
-    $ dig -p 53 @localhost myhost.vagrant.dev
+    $ dig -p 53 @localhost myhost.vagrant.test
 
 ## Configure DNS server on your mobile phone
 Set your bind server's IP address as the DNS server on your external device.

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -1,4 +1,4 @@
-# 
+#
 # This serves as a simple example, and it's what I'm using for testing locally.
 #
 # If you're doing development and want to run this locally you can simply
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
 
   config.landrush.enabled = true
 
-  config.vm.hostname = "myhost.vagrant.dev"
+  config.vm.hostname = "myhost.vagrant.test"
 
   config.landrush.host 'static1.example.com', '1.2.3.4'
   config.landrush.host 'static2.example.com', '2.3.4.5'

--- a/issues/vbox/Vagrantfile
+++ b/issues/vbox/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = 'precise64'
   config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
-  config.vm.hostname = 'vbox.vagrant.dev'
+  config.vm.hostname = 'vbox.vagrant.test'
   config.landrush.enable
 
   # The url from where the 'config.vm.box' box will be fetched if it

--- a/lib/landrush/config.rb
+++ b/lib/landrush/config.rb
@@ -9,7 +9,7 @@ module Landrush
 
     DEFAULTS = {
       :enabled => false,
-      :tld => 'vagrant.dev',
+      :tld => 'vagrant.test',
       :upstream_servers => [[:udp, '8.8.8.8', 53], [:tcp, '8.8.8.8', 53]],
       :host_ip_address => nil,
       :guest_redirect_dns => true

--- a/test/landrush/action/setup_test.rb
+++ b/test/landrush/action/setup_test.rb
@@ -25,7 +25,7 @@ module Landrush
 
         setup.call(env)
 
-        DependentVMs.list.must_equal %w[somehost.vagrant.dev]
+        DependentVMs.list.must_equal %w[somehost.vagrant.test]
       end
 
       it "starts the landrush server if it's not already started" do
@@ -71,7 +71,7 @@ module Landrush
 
           setup.call(env)
 
-          Store.hosts.get('somehost.vagrant.dev').must_equal '1.2.3.4'
+          Store.hosts.get('somehost.vagrant.test').must_equal '1.2.3.4'
         end
 
         it "does nothing if it is not enabled via config" do
@@ -81,7 +81,7 @@ module Landrush
 
           setup.call(env)
 
-          Store.hosts.get('somehost.vagrant.dev').must_equal nil
+          Store.hosts.get('somehost.vagrant.test').must_equal nil
         end
       end
     end

--- a/test/landrush/action/teardown_test.rb
+++ b/test/landrush/action/teardown_test.rb
@@ -20,10 +20,10 @@ module Landrush
         teardown = Teardown.new(app, nil)
         env = fake_environment
 
-        Store.hosts.set('somehost.vagrant.dev', '1.2.3.4')
+        Store.hosts.set('somehost.vagrant.test', '1.2.3.4')
         teardown.call(env)
 
-        Store.hosts.get('somehost.vagrant.dev').must_equal nil
+        Store.hosts.get('somehost.vagrant.test').must_equal nil
       end
 
       it "removes the machine as a dependent VM" do
@@ -31,7 +31,7 @@ module Landrush
         teardown = Teardown.new(app, nil)
         env = fake_environment
 
-        DependentVMs.add('somehost.vagrant.dev')
+        DependentVMs.add('somehost.vagrant.test')
         teardown.call(env)
 
         DependentVMs.list.must_equal []
@@ -52,7 +52,7 @@ module Landrush
         app = Proc.new {}
         teardown = Teardown.new(app, nil)
         env = fake_environment
-        DependentVMs.add('otherhost.vagrant.dev')
+        DependentVMs.add('otherhost.vagrant.test')
 
         Server.start
         teardown.call(env)
@@ -64,13 +64,13 @@ module Landrush
         app = Proc.new {}
         teardown = Teardown.new(app, nil)
         env = fake_environment
-        DependentVMs.add('otherhost.vagrant.dev')
+        DependentVMs.add('otherhost.vagrant.test')
 
-        fake_static_entry(env, 'static.vagrant.dev', '3.4.5.6')
+        fake_static_entry(env, 'static.vagrant.test', '3.4.5.6')
 
         teardown.call(env)
 
-        Store.hosts.get('static.vagrant.dev').must_equal '3.4.5.6'
+        Store.hosts.get('static.vagrant.test').must_equal '3.4.5.6'
       end
 
       it "leaves the server alone if it's not running" do
@@ -86,7 +86,7 @@ module Landrush
       it "does nothing when landrush is disabled" do
         # somewhat unrealistic since this entry shouldn't be there if it was
         # disabled in the first place, but oh well
-        Store.hosts.set('somehost.vagrant.dev', '1.2.3.4')
+        Store.hosts.set('somehost.vagrant.test', '1.2.3.4')
 
         app = Proc.new {}
         teardown = Teardown.new(app, nil)
@@ -96,7 +96,7 @@ module Landrush
 
         teardown.call(env)
 
-        Store.hosts.get('somehost.vagrant.dev').must_equal '1.2.3.4'
+        Store.hosts.get('somehost.vagrant.test').must_equal '1.2.3.4'
       end
     end
   end

--- a/test/landrush/dependent_vms_test.rb
+++ b/test/landrush/dependent_vms_test.rb
@@ -8,20 +8,20 @@ module Landrush
       end
 
       it "reports true once a machine has been added" do
-        DependentVMs.add('recordme.example.dev')
+        DependentVMs.add('recordme.example.test')
         DependentVMs.any?.must_equal true
       end
 
       it "reports false if a machine has been added then removed" do
-        DependentVMs.add('recordme.example.dev')
-        DependentVMs.remove('recordme.example.dev')
+        DependentVMs.add('recordme.example.test')
+        DependentVMs.remove('recordme.example.test')
         DependentVMs.any?.must_equal false
       end
 
       it "reports true if not all machines have been removed" do
-        DependentVMs.add('recordme.example.dev')
-        DependentVMs.add('alsome.example.dev')
-        DependentVMs.remove('recordme.example.dev')
+        DependentVMs.add('recordme.example.test')
+        DependentVMs.add('alsome.example.test')
+        DependentVMs.remove('recordme.example.test')
         DependentVMs.any?.must_equal true
       end
     end

--- a/test/landrush/server_test.rb
+++ b/test/landrush/server_test.rb
@@ -35,7 +35,7 @@ module Landrush
       it 'responds properly to configured machine entries' do
         Server.start
 
-        fake_host = 'boogers.vagrant.dev'
+        fake_host = 'boogers.vagrant.test'
         fake_ip = '99.98.97.96'
 
         Store.hosts.set(fake_host, fake_ip)
@@ -48,8 +48,8 @@ module Landrush
       it 'responds properly to configured cname entries' do
         Server.start
 
-        fake_host = 'boogers.vagrant.dev'
-        fake_cname = 'snot.vagrant.dev'
+        fake_host = 'boogers.vagrant.test'
+        fake_cname = 'snot.vagrant.test'
         fake_ip = '99.98.97.96'
 
         Store.hosts.set(fake_host, fake_ip)
@@ -62,7 +62,7 @@ module Landrush
       it 'also resolves wildcard subdomains to a given machine' do
         Server.start
 
-        fake_host = 'boogers.vagrant.dev'
+        fake_host = 'boogers.vagrant.test'
         fake_ip = '99.98.97.96'
 
         Store.hosts.set(fake_host, fake_ip)

--- a/test/landrush/store_test.rb
+++ b/test/landrush/store_test.rb
@@ -54,24 +54,24 @@ module Landrush
 
     describe "find" do
       it "returns the key that matches the end of the search term" do
-        @store.set('somehost.vagrant.dev', 'here')
+        @store.set('somehost.vagrant.test', 'here')
 
-        @store.find('foo.somehost.vagrant.dev').must_equal 'somehost.vagrant.dev'
-        @store.find('bar.somehost.vagrant.dev').must_equal 'somehost.vagrant.dev'
-        @store.find('foo.otherhost.vagrant.dev').must_equal nil
-        @store.find('host.vagrant.dev').must_equal nil
+        @store.find('foo.somehost.vagrant.test').must_equal 'somehost.vagrant.test'
+        @store.find('bar.somehost.vagrant.test').must_equal 'somehost.vagrant.test'
+        @store.find('foo.otherhost.vagrant.test').must_equal nil
+        @store.find('host.vagrant.test').must_equal nil
       end
 
       it "returns exact matches too" do
-        @store.set('somehost.vagrant.dev', 'here')
-        @store.find('somehost.vagrant.dev').must_equal 'somehost.vagrant.dev'
+        @store.set('somehost.vagrant.test', 'here')
+        @store.find('somehost.vagrant.test').must_equal 'somehost.vagrant.test'
       end
 
       it "returns for prefix searches as well" do
-        @store.set('somehost.vagrant.dev', 'here')
+        @store.set('somehost.vagrant.test', 'here')
 
-        @store.find('somehost').must_equal 'somehost.vagrant.dev'
-        @store.find('somehost.vagrant').must_equal 'somehost.vagrant.dev'
+        @store.find('somehost').must_equal 'somehost.vagrant.test'
+        @store.find('somehost.vagrant').must_equal 'somehost.vagrant.test'
         @store.find('somehost.vagr').must_equal nil
         @store.find('someh').must_equal nil
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -97,7 +97,7 @@ def fake_machine(options={})
   )
 
   machine.config.landrush.enabled = options.fetch(:enabled, false)
-  machine.config.vm.hostname = options.fetch(:hostname, 'somehost.vagrant.dev')
+  machine.config.vm.hostname = options.fetch(:hostname, 'somehost.vagrant.test')
 
   machine
 end


### PR DESCRIPTION
Based on #146
Closes #118

I suggest we should change the TLD, because ".dev" leads to problems, see #118.

@ahpook @strzibny @fh @bexelbie wdyt? please review