### PR TITLE
Add "minitest" dependency to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,5 @@ group :development do
 
   gem 'byebug'
   gem 'mocha'
+  gem 'minitest'
 end


### PR DESCRIPTION
@ahpook @strzibny @fh @bexelbie please review

I think this is missing, as it's used in `test/test_helper.rb`.